### PR TITLE
Adding dist and node_modules folders to a root .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,4 +1,0 @@
--# Ignore everything in this directory
--*
--# Except this file
--!.gitignore

--- a/node_modules/.gitignore
+++ b/node_modules/.gitignore
@@ -1,4 +1,0 @@
--# Ignore everything in this directory
--*
--# Except this file
--!.gitignore


### PR DESCRIPTION
This change removes the `dist` and `node_modules` folders from the repository, and ignores the folders in Git. They are unnecessary as `gulp` and `npm` respectively will recreate the folders as needed. I have tested this.

Otherwise, running `git status` will show a long list of Node modules in the "Untracked files" section, plus folders and files inside `/dist`.

Since there's no `dev` branch I'm requesting this is merged into `master`. I agree to the [CLA](https://github.com/Chicago/contributor-license-agreement/blob/7034c76221c11c7d526a30fea18725c4716b8dff/chicago_cla.md) in its current state.