### PR TITLE
Fixed ending time when using "between" operator

### DIFF
--- a/lib/jquery-1.11.2/opengrid-query-builder.js
+++ b/lib/jquery-1.11.2/opengrid-query-builder.js
@@ -2700,7 +2700,7 @@
                                 valuesCopy = [].concat(rule.value);
                                 if (rule.type === 'date') {
                                     $.each(valuesCopy, function(i, v) {
-                                        valuesCopy[i] = that._getDateValue(v);
+                                        valuesCopy[i] = that._getArrayElementDateValue(i, v);
                                     });
                                 }
                             }
@@ -2735,25 +2735,23 @@
                     //rule.value = '$currentDate';
 
                     //assume: datetime on target is stored in Mongo as a numeric value representing Unix epoch in ms
-                    //rule.value = moment().valueOf();
-                    rule.value = moment(chrono.parseDate(rule.value)).startOf('day').valueOf();
-                    return rule.value;
+                    return moment(chrono.parseDate(rule.value)).startOf('day').valueOf();
                 } else
-                    return this._getDateValue(rule.value);
+                    return moment(rule.value, "MM/DD/YYYY hh:mm:ss a").valueOf();
             } else
                 return rule.value;
         },
 
-        _getDateValue: function(value) {
+        //assume only 'between' operator can be applied
+        _getArrayElementDateValue: function(i, value) {
             if (this.isNaturalLangChronoValue(value) ) {
                 //map to Mongo's current date time token
-                //this does not work for datetime values stored as numeric
-                //rule.value = '$currentDate';
 
                 //assume: datetime on target is stored in Mongo as a numeric value representing Unix epoch in ms
-                //rule.value = moment().valueOf();
-                //value = moment(chrono.parseDate(value)).valueOf();
-                value = moment(chrono.parseDate(value)).startOf('day').valueOf();
+                if (i==1)
+                    value = moment(chrono.parseDate(value)).endOf('day').valueOf();
+                else
+                    value = moment(chrono.parseDate(value)).startOf('day').valueOf();
                 return value;
             } else {
                 //assume: datetime on target is stored in Mongo as a numeric value representing Unix epoch in ms


### PR DESCRIPTION
Fixed ending time when using "between" operator with relative dates (Related to issue #147)