### PR TITLE
Fixed issue #321

### DIFF
--- a/src/js/ux/TableView.js
+++ b/src/js/ux/TableView.js
@@ -301,9 +301,6 @@ ogrid.TableView = ogrid.Class.extend({
        if (view.options.chart) {
            return view.options.chart;
        } else {
-           if (!view.options.creationTimestamp) {
-               throw ogrid.error('Configuration Error', 'No "creationTimestamp" field defined for this dataset (Table View)');
-           }
            return {
                //by default, use creation timestamp column
                "xAxisField": view.options.creationTimestamp,


### PR DESCRIPTION
Fixed issue #321 by removing unnecessary check on view.creationTimestamp field. Chart class is able to handle nulls correctly.